### PR TITLE
Allow options and more_options to be merged

### DIFF
--- a/lib/apexcharts/charts/cartesian.rb
+++ b/lib/apexcharts/charts/cartesian.rb
@@ -6,7 +6,8 @@ module Apexcharts
 
     def initialize bindings, data, options={}, &block
       @bindings = bindings
-      options = {**options, **more_options}
+      options = Utils::Hash.deep_merge(Utils::Hash.camelize_keys(options), Utils::Hash.camelize_keys(more_options))
+
       build_instance_variables if @bindings
 
       instance_eval &block if block_given?

--- a/spec/charts/bar_spec.rb
+++ b/spec/charts/bar_spec.rb
@@ -29,5 +29,21 @@ RSpec.describe Apexcharts::ColumnChart do
       ]
     )
   end
+
+  it 'merged options and more_options correctly' do
+    options = { plotOptions: { bar: { dataLabels: { position: "top" } } } }
+    chart = described_class.new(bindings, data, options)
+
+    expect(chart.instance_variable_get(:@options)[:plotOptions]).to eq(
+      {
+        bar: {
+          dataLabels: {
+            position: "top"
+          },
+          horizontal: false
+        }
+      }
+    )
+  end
 end
 


### PR DESCRIPTION
Previously, the more_options hash of a column or bar chart
would overwrite any options passed in if there was a collision.
This change allows options for plotOptions to be passed in
and merged with more_options without being overwritten.