### PR TITLE
Fixed bug Utils::Hash.camelize_keys not camelizing keys of hash in array value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,8 @@ All notable changes to this project will be documented in this file.
 - `plot_options` not deeply merged on bar and column chart when
   `options` contains `plot_options`
 - Undefined method `to_json` for `options` when not using Rails
+- Utils::Hash.camelize_keys not camelizing keys of hash in array
+  value
 
 
 ## [0.1.4] - 2019-07-06

--- a/lib/apexcharts/utils/hash.rb
+++ b/lib/apexcharts/utils/hash.rb
@@ -1,6 +1,8 @@
 module Apexcharts
   module Utils
     module Hash
+      module_function
+
       def deep_merge(first_hash, second_hash)
         first_hash.merge(second_hash) do |key, this_val, other_val|
           if this_val.is_a?(::Hash) && other_val.is_a?(::Hash)
@@ -10,21 +12,21 @@ module Apexcharts
           end
         end
       end
-      module_function :deep_merge
 
       def camelize(key)
         key.to_s.gsub(/_(.)/) {|m| m[1].upcase }.to_sym
       end
-      module_function :camelize
 
       def camelize_keys(value)
-        if value.is_a? ::Hash
+        case value
+        when ::Hash
           ::Hash[value.map {|k, v| [camelize(k), camelize_keys(v)] }]
+        when Array
+          value.map {|e| camelize_keys(e) }
         else
           value
         end
       end
-      module_function :camelize_keys
     end
   end
 end

--- a/spec/utils/hash_spec.rb
+++ b/spec/utils/hash_spec.rb
@@ -54,7 +54,7 @@ RSpec.describe Apexcharts::Utils::Hash do
   end
 
   context ".camelize_keys" do
-    it "camelizes keys of a hash" do
+    it "camelizes keys of the hash" do
       expect(described_class.camelize_keys(
         {
           check_this_out: {
@@ -68,6 +68,28 @@ RSpec.describe Apexcharts::Utils::Hash do
           }
         }
       )
+    end
+
+    context "when the value is an array containing hash" do
+      it "also camelizes keys of the hash inside array" do
+        expect(described_class.camelize_keys(
+          {
+            check_this_out: [
+              {
+                "this_is_great" => "cool"
+              }
+            ]
+          }
+        )).to eq(
+          {
+            checkThisOut: [
+              {
+                thisIsGreat: "cool"
+              }
+            ]
+          }
+        )
+      end
     end
   end
 end


### PR DESCRIPTION
### Previously
`{a_b: [{b_c: 2}]}` becomes `{aB:[{b_c: 2}]}`

### Now
`{a_b: [{b_c: 2}]}` becomes `{aB:[{bC: 2}]}` 