### PR TITLE
Remove `sudo: false` and always use the latest teeny versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 ---
-sudo: false
 language: ruby
 cache: bundler
 rvm:
-  - 2.4.6
-  - 2.5.5
-  - 2.6.3
+  - 2.4
+  - 2.5
+  - 2.6
 before_install: gem install bundler -v 2.0.1


### PR DESCRIPTION
`sudo: false` is now the default.