### PR TITLE
Change number to numeric

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ All notable changes to this project will be documented in this file.
 - Security section in repo page
 - Table of Contents
 
+## Changed
+- X and Y axis type `number` to `numeric`
+
 ### Fixed
 - HTML+ERB wrong instruction
 

--- a/lib/apexcharts/options_builder.rb
+++ b/lib/apexcharts/options_builder.rb
@@ -311,7 +311,7 @@ module ApexCharts
         'datetime'
       end
     rescue
-      'number'
+      'numeric'
     end
 
     def enabled(options)

--- a/lib/apexcharts/utils/date_time.rb
+++ b/lib/apexcharts/utils/date_time.rb
@@ -48,11 +48,11 @@ module ApexCharts::Utils
         elsif Date.iso8601(input).iso8601 == input
           'datetime'
         else
-          'number'
+          'numeric'
         end
       end
     rescue
-      'number'
+      'numeric'
     end
     module_function :type
   end

--- a/spec/options_builder/xaxis_spec.rb
+++ b/spec/options_builder/xaxis_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe '#build_xaxis' do
   context 'xaxis is a string' do
     let(:options) {
       {
-        xtype: "number",
+        xtype: "numeric",
         xtitle: "X-Title",
         xaxis: "Title"
       }
@@ -17,7 +17,7 @@ RSpec.describe '#build_xaxis' do
     let(:expected_built) {
       {
         xaxis: {
-          type: "number",
+          type: "numeric",
           title: {
             text: "Title"
           }
@@ -34,7 +34,7 @@ RSpec.describe '#build_xaxis' do
   context 'xaxis is a hash' do
     let(:options) {
       {
-        xtype: "number",
+        xtype: "numeric",
         xtitle: "X-Title",
         xaxis: {
           position: "top",
@@ -64,13 +64,13 @@ RSpec.describe '#build_xaxis' do
     let(:x_sample) { Time.now }
     let(:options) {
       {
-        xtype: "number",
+        xtype: "numeric",
       }
     }
     let(:expected_built) {
       {
         xaxis: {
-          type: "number",
+          type: "numeric",
         }
       }
     }

--- a/spec/options_builder/yaxis_spec.rb
+++ b/spec/options_builder/yaxis_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe '#build_yaxis' do
   context 'yaxis is a string' do
     let(:options) {
       {
-        ytype: "number",
+        ytype: "numeric",
         ytitle: "Y-Title",
         yaxis: "Title"
       }
@@ -17,7 +17,7 @@ RSpec.describe '#build_yaxis' do
     let(:expected_built) {
       {
         yaxis: [{
-          type: "number",
+          type: "numeric",
           title: {
             text: "Title"
           }
@@ -34,7 +34,7 @@ RSpec.describe '#build_yaxis' do
   context 'yaxis is a hash' do
     let(:options) {
       {
-        ytype: "number",
+        ytype: "numeric",
         ytitle: "Y-Title",
         yaxis: {
           type: "datetime"

--- a/spec/utils/date_time_spec.rb
+++ b/spec/utils/date_time_spec.rb
@@ -186,7 +186,7 @@ RSpec.describe ApexCharts::Utils::DateTime do
       let(:input) { ["2"] }
 
       it 'converts correctly' do
-        expect(type).to eq 'number'
+        expect(type).to eq 'numeric'
       end
     end
   end


### PR DESCRIPTION
Although no errors occur when using `number`, the official type is `numeric`.