### PR TITLE
Add documentation for the options Hash

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ a beautiful, interactive, and responsive charts for your ruby app.
   - [Radar Chart](#radar-chart-1)
   - [Bubble Chart](#bubble-chart-1)
   - [Polar Charts](#polar-charts-1)
+- [Options (Reference)](#options-reference)
 - [Installation](#installation)
 - [Web Support](#web-support)
   - [Rails](#rails)
@@ -481,6 +482,52 @@ for bubble size:
 ### Polar Charts
 The data format for donut, pie, and radial bar are the simplest. They are
 just any single value of type Numeric.
+
+
+## Options (Reference)
+ApexCharts.rb supports [all options from apexcharts.js](https://apexcharts.com/docs/options/), but instead of camelCase, you can write them in snake_case.
+
+ApexCharts.rb also provides shortcuts to some ApexCharts.js options, such as `title`. In ApexCharts.js you would have to write `title: { text: "Some title" }`. In ApexCharts.rb you can write `title: "Some title"` if you just want to add the text.
+`xtitle` and `ytitle` are even greater shortcuts. Instead of `xaxis: { title: { text: "x title" } }` you can write `xtitle: "x title"`."
+
+```ruby
+options = {
+  animations: false, # Shortcut for chart: { animations: { enabled: false } }
+  chart: {
+    fontFamily: "Helvetica, Arial, sans-serif",
+    toolbar: {
+      show: false
+    }
+  },
+  curve: "straight", # Shortcut for stroke: { curve: "straight" }
+  markers: {
+    size: 5,
+  },
+  tooltip: false, # Shortcut for tooltip: { enabled: false }
+  xtitle: "Boars per capita"
+}
+```
+
+These options can be passed to any chart helper like `<%= line_chart(series, options) %>`.
+
+### Global options
+
+To change options globally, you can manipulate the `Apex` JavaScript object directly:
+
+```javascript
+require("apexcharts")
+
+const apexGlobalOptions = {
+  chart: {
+    …
+  },
+  …
+}
+
+Object.assign(Apex, apexGlobalOptions)
+```
+
+All charts will then be created with these global options, which can be overwritten individually by any ApexCharts.rb helper method.
 
 
 ## Installation


### PR DESCRIPTION
As suggested [here](https://github.com/styd/apexcharts.rb/issues/25) this small PR adds documentation for the options Hash.

Edit: Should I transcribe [all currently available options from the ApexCharts JS docs](https://apexcharts.com/docs/options/) into the ApexCharts.rb docs or would that be too long/unnecessary duplication?