### PR TITLE
Make palette helpers work locally

### DIFF
--- a/lib/apexcharts/helper.rb
+++ b/lib/apexcharts/helper.rb
@@ -83,11 +83,11 @@ module ApexCharts
     alias_method :circle_chart, :radial_bar_chart
 
     def create_palette palette_name, colors
-      ApexCharts::Theme.create palette_name, colors
+      ApexCharts::Theme::Local.create palette_name, colors
     end
 
     def destroy_palette palette_name
-      ApexCharts::Theme.destroy palette_name
+      ApexCharts::Theme::Local.destroy palette_name
     end
 
   private

--- a/lib/apexcharts/options_builder.rb
+++ b/lib/apexcharts/options_builder.rb
@@ -232,7 +232,7 @@ module ApexCharts
       @built[:theme] = if theme.is_a? String
                          case theme
                          when 'random'
-                           {palette: ApexCharts::Theme.all_palettes.sample}
+                           resolve_theme(Theme::Local.all_palettes.sample)
                          when 'monochrome'
                            {monochrome: {enabled: true}}
                          else
@@ -337,8 +337,8 @@ module ApexCharts
     def resolve_theme(theme)
       if Theme::PALETTES.include? theme
         {palette: theme}
-      elsif Theme.custom_palettes.include? theme
-        @built[:colors] = Theme.get_colors(theme)
+      elsif Theme::Local.palette_names.include? theme
+        @built[:colors] = Theme::Local.get_colors(theme)
         nil
       end
     end

--- a/lib/apexcharts/theme.rb
+++ b/lib/apexcharts/theme.rb
@@ -9,27 +9,57 @@ module ApexCharts
 
     @custom_palettes = {}
 
-    class << self
+    module ClassMethods
       def create palette_name, colors
-        @custom_palettes[palette_name] = Colors.new colors
+        palettes[palette_name] = Colors.new colors
       end
 
       def destroy palette_name
-        @custom_palettes.delete palette_name
+        palettes.delete palette_name
       end
 
       def get_colors(palette_name)
-        @custom_palettes[palette_name]&.values
+        custom_palettes[palette_name]&.values
       end
 
-      def custom_palettes
-        @custom_palettes.keys
+      def palette_names
+        palettes.keys
       end
 
       def all_palettes
-        PALETTES + custom_palettes
+        PALETTES + palette_names
+      end
+
+      def custom_palettes
+        palettes
+      end
+
+      def palettes
+        @custom_palettes
       end
     end
+
+    class Local
+      module LocalClassMethods
+        include ClassMethods
+
+        def palette_names
+          super + ApexCharts::Theme.palettes.keys
+        end
+
+        def custom_palettes
+          ApexCharts::Theme.palettes.merge(super)
+        end
+
+        def palettes
+          Thread.current[:_ApexCharts_Palettes_] ||= {}
+        end
+      end
+
+      extend LocalClassMethods
+    end
+
+    extend ClassMethods
   end
 end
 

--- a/spec/colors_spec.rb
+++ b/spec/colors_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-describe ApexCharts::Colors do
+RSpec.describe ApexCharts::Colors do
   context '#values' do
     context 'when input is a string' do
       context 'of a valid color' do

--- a/spec/options_builder/theme_spec.rb
+++ b/spec/options_builder/theme_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe '#build_theme' do
       }
 
       before do
-        allow(ApexCharts::Theme).to(
+        allow(ApexCharts::Theme::Local).to(
           receive(:all_palettes).and_return(['palette4'])
         )
       end
@@ -62,7 +62,7 @@ RSpec.describe '#build_theme' do
       let(:expected_built) {
         {
           theme: nil,
-          colors: ApexCharts::Theme.get_colors('my_palette')
+          colors: ApexCharts::Theme::Local.get_colors('my_palette')
         }
       }
 

--- a/spec/theme_spec.rb
+++ b/spec/theme_spec.rb
@@ -1,17 +1,11 @@
 require 'spec_helper'
 
-describe ApexCharts::Theme do
-  context '::PALETTES' do
-    it 'has 10 palettes' do
-      expect(described_class::PALETTES.size).to eq 10
-    end
-  end
-
+RSpec.shared_examples 'apexcharts_theme' do
   context '.create' do
     it 'creates a new palette' do
       described_class.create "my_palette", ["#aabbcc", "#bbccdd"]
 
-      expect(described_class.custom_palettes).to eq ["my_palette"]
+      expect(described_class.palette_names).to eq ["my_palette"]
       expect(described_class.get_colors("my_palette")).to eq ["#AABBCC", "#BBCCDD"]
     end
 
@@ -55,6 +49,40 @@ describe ApexCharts::Theme do
 
       expect(described_class.all_palettes.size).to eq 11
       expect(described_class.all_palettes).to include 'my_palette'
+
+      described_class.destroy "my_palette"
+    end
+  end
+end
+
+RSpec.describe ApexCharts::Theme do
+  it_behaves_like 'apexcharts_theme'
+
+  context '::PALETTES' do
+    it 'has 10 palettes' do
+      expect(described_class::PALETTES.size).to eq 10
+    end
+  end
+
+  describe described_class::Local do
+    it_behaves_like 'apexcharts_theme'
+
+    after do
+      Thread.current[:_ApexCharts_Palettes_] = {}
+    end
+
+    it 'calls a hash on current thread variable' do
+      expect(Thread.current).to receive(:[]).with(:_ApexCharts_Palettes_).and_return({})
+      described_class.palettes
+    end
+
+    it 'works only on current thread' do
+      described_class.create 'local_theme', ["#aabbcc", "#bbccdd", "#ccddee"]
+      expect(described_class.all_palettes.size).to eq 11
+      Thread.new {
+        expect(described_class.all_palettes.size).to eq 10
+      }
+      expect(described_class.all_palettes.size).to eq 11
     end
   end
 end


### PR DESCRIPTION
Helpers should not alter things globally. With this, helpers only work on current thread or usually for the duration of a request for rack apps.