### PR TITLE
Fix cannot specify xtype or ytype as root options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,7 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 - HTML+ERB wrong and ambiguous instruction
+- Cannot specify xtype or ytype as root options
 
 
 ## [0.1.5] - 2019-07-20

--- a/lib/apexcharts/options/root.rb
+++ b/lib/apexcharts/options/root.rb
@@ -31,8 +31,10 @@ module ApexCharts
                   var
                   xaxis
                   xtitle
+                  xtype
                   yaxis
                   ytitle
+                  ytype
                 ],
              *DivAttributes.optional_keys,
              *ChartOptions.optional_keys,


### PR DESCRIPTION
xtype and ytype already read on options builder
but not allowed as root options.