### PR TITLE
Cleanup building options and their tests

### DIFF
--- a/lib/apexcharts/options_builder.rb
+++ b/lib/apexcharts/options_builder.rb
@@ -36,6 +36,10 @@ module ApexCharts
 
       build_chart
       build_div
+      build_default_options
+    end
+
+    def build_default_options
       build_annotations
       build_colors
       build_data_labels
@@ -268,6 +272,8 @@ module ApexCharts
         XAxisOptions.check xaxis
         @built[:xaxis].merge! xaxis
       end
+
+      @built[:xaxis] = nil if @built[:xaxis].empty?
     end
 
     def build_yaxis
@@ -286,6 +292,8 @@ module ApexCharts
         YAxisOptions.check yaxis
         @built[:yaxis][0].merge! yaxis
       end
+
+      @built[:yaxis] = nil if @built[:yaxis].all?(&:empty?)
     end
 
     def type(input)

--- a/lib/apexcharts/utils/date_time.rb
+++ b/lib/apexcharts/utils/date_time.rb
@@ -53,16 +53,14 @@ module ApexCharts
         when Time, ::DateTime, Date
           'datetime'
         else
-          if ::DateTime.iso8601(input).iso8601 == input
-            'datetime'
-          elsif Date.iso8601(input).iso8601 == input
+          if ::DateTime.iso8601(input).iso8601 == input ||
+              Date.iso8601(input).iso8601 == input
             'datetime'
           else
             'numeric'
           end
         end
       rescue StandardError
-        'numeric'
       end
     end
   end

--- a/spec/options_builder/annotations_spec.rb
+++ b/spec/options_builder/annotations_spec.rb
@@ -48,6 +48,6 @@ RSpec.describe '#build_annotations' do
 
   it 'only camelizes the hash keys' do
     ob.build_annotations
-    expect(ob.built).to match(hash_including(expected_built))
+    expect(ob.built).to match(expected_built)
   end
 end

--- a/spec/options_builder/chart_spec.rb
+++ b/spec/options_builder/chart_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe '#build_chart' do
 
   it 'extract chart related key-values' do
     ob.build_chart
-    expect(ob.built).to match(hash_including(expected_built))
+    expect(ob.built).to match(expected_built)
   end
 
   context 'brush chart' do
@@ -64,7 +64,7 @@ RSpec.describe '#build_chart' do
 
     it 'extract brush chart target' do
       ob.build_chart
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 end

--- a/spec/options_builder/colors_spec.rb
+++ b/spec/options_builder/colors_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe '#build_colors' do
 
     it 'return colors with nil value' do
       ob.build_colors
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -38,7 +38,7 @@ RSpec.describe '#build_colors' do
 
     it 'return colors with array value' do
       ob.build_colors
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -56,7 +56,7 @@ RSpec.describe '#build_colors' do
 
     it 'return colors with array value' do
       ob.build_colors
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 end

--- a/spec/options_builder/data_labels_spec.rb
+++ b/spec/options_builder/data_labels_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe '#build_data_labels' do
 
     it 'adds enabled key with the boolean as the value' do
       ob.build_data_labels
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -58,7 +58,7 @@ RSpec.describe '#build_data_labels' do
 
     it 'only camelizes the hash' do
       ob.build_data_labels
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 end

--- a/spec/options_builder/div_spec.rb
+++ b/spec/options_builder/div_spec.rb
@@ -26,6 +26,6 @@ RSpec.describe '#build_div' do
 
   it 'extract div related key-values' do
     ob.build_div
-    expect(ob.built).to match(hash_including(expected_built))
+    expect(ob.built).to match(expected_built)
   end
 end

--- a/spec/options_builder/fill_spec.rb
+++ b/spec/options_builder/fill_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe '#build_fill' do
 
     it 'adds type key with the string as the value' do
       ob.build_fill
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -41,7 +41,7 @@ RSpec.describe '#build_fill' do
 
     it 'keeps the hash intact' do
       ob.build_fill
-      expect(ob.built).to match(hash_including(options))
+      expect(ob.built).to match(options)
     end
   end
 end

--- a/spec/options_builder/grid_spec.rb
+++ b/spec/options_builder/grid_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe '#build_grid' do
 
     it 'adds show key with the boolean as the value' do
       ob.build_grid
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -48,7 +48,7 @@ RSpec.describe '#build_grid' do
 
     it 'only camelizes the hash' do
       ob.build_grid
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 end

--- a/spec/options_builder/labels_spec.rb
+++ b/spec/options_builder/labels_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe '#build_labels' do
 
     it 'return labels with nil value' do
       ob.build_labels
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -38,7 +38,7 @@ RSpec.describe '#build_labels' do
 
     it 'return labels with array value' do
       ob.build_labels
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -56,7 +56,7 @@ RSpec.describe '#build_labels' do
 
     it 'return labels with array value' do
       ob.build_labels
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 end

--- a/spec/options_builder/legend_spec.rb
+++ b/spec/options_builder/legend_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe '#build_legend' do
 
     it 'adds show key with the boolean as the value' do
       ob.build_legend
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -43,7 +43,7 @@ RSpec.describe '#build_legend' do
 
     it 'adds show key with value true and position key with the string as the value' do
       ob.build_legend
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -63,7 +63,7 @@ RSpec.describe '#build_legend' do
 
     it 'keeps the hash intact' do
       ob.build_legend
-      expect(ob.built).to match(hash_including(options))
+      expect(ob.built).to match(options)
     end
   end
 end

--- a/spec/options_builder/markers_spec.rb
+++ b/spec/options_builder/markers_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe '#build_markers' do
 
     it 'adds shape key with the string as the value' do
       ob.build_markers
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -53,7 +53,7 @@ RSpec.describe '#build_markers' do
     }
     it 'only camelizes the hash' do
       ob.build_markers
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 end

--- a/spec/options_builder/no_data_spec.rb
+++ b/spec/options_builder/no_data_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe '#build_no_data' do
     }
     it 'adds shape key with the string as the value' do
       ob.build_no_data
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -47,7 +47,7 @@ RSpec.describe '#build_no_data' do
 
     it 'only camelizes the hash' do
       ob.build_no_data
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 end

--- a/spec/options_builder/plot_options_spec.rb
+++ b/spec/options_builder/plot_options_spec.rb
@@ -34,6 +34,6 @@ RSpec.describe '#build_plot_options' do
 
   it 'camelizes the hash' do
     hash_ob.build_plot_options
-    expect(hash_ob.built).to match(hash_including(expected_plot_options_built))
+    expect(hash_ob.built).to match(expected_plot_options_built)
   end
 end

--- a/spec/options_builder/responsive_spec.rb
+++ b/spec/options_builder/responsive_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe '#build_responsive' do
 
     it 'return responsive with nil value' do
       ob.build_responsive
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -38,7 +38,7 @@ RSpec.describe '#build_responsive' do
 
     it 'return responsive with array value' do
       ob.build_responsive
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -56,7 +56,7 @@ RSpec.describe '#build_responsive' do
 
     it 'return responsive with array value' do
       ob.build_responsive
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 end

--- a/spec/options_builder/states_spec.rb
+++ b/spec/options_builder/states_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe '#build_states' do
 
     it 'only camelizes the hash' do
       ob.build_states
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -72,7 +72,7 @@ RSpec.describe '#build_states' do
 
     it 'only camelizes the hash' do
       ob.build_states
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 end

--- a/spec/options_builder/stroke_spec.rb
+++ b/spec/options_builder/stroke_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe '#build_stroke' do
 
     it 'adds show key with the boolean as the value' do
       ob.build_stroke
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -42,7 +42,7 @@ RSpec.describe '#build_stroke' do
 
     it 'adds show key with the boolean as the value' do
       ob.build_stroke
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -66,7 +66,7 @@ RSpec.describe '#build_stroke' do
 
     it 'only camelizes the hash' do
       ob.build_stroke
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 end

--- a/spec/options_builder/subtitle_spec.rb
+++ b/spec/options_builder/subtitle_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe '#build_subtitle' do
 
     it 'adds shape key with the string as the value' do
       ob.build_subtitle
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -46,7 +46,7 @@ RSpec.describe '#build_subtitle' do
 
     it 'only camelizes the hash' do
       ob.build_subtitle
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 end

--- a/spec/options_builder/theme_spec.rb
+++ b/spec/options_builder/theme_spec.rb
@@ -29,7 +29,7 @@ RSpec.describe '#build_theme' do
 
       it 'adds theme value as palette' do
         ob.build_theme
-        expect(ob.built).to match(hash_including(expected_built))
+        expect(ob.built).to match(expected_built)
       end
     end
 
@@ -49,7 +49,7 @@ RSpec.describe '#build_theme' do
 
       it 'adds monochrome as enabled' do
         ob.build_theme
-        expect(ob.built).to match(hash_including(expected_built))
+        expect(ob.built).to match(expected_built)
       end
     end
 
@@ -70,7 +70,7 @@ RSpec.describe '#build_theme' do
         ApexCharts::Theme.create 'my_palette', ['#aabbcc', '#bbccdd']
 
         ob.build_theme
-        expect(ob.built).to match(hash_including(expected_built))
+        expect(ob.built).to match(expected_built)
       end
     end
 
@@ -88,7 +88,7 @@ RSpec.describe '#build_theme' do
 
       it 'adds theme value as palette' do
         ob.build_theme
-        expect(ob.built).to match(hash_including(expected_built))
+        expect(ob.built).to match(expected_built)
       end
     end
   end
@@ -117,7 +117,7 @@ RSpec.describe '#build_theme' do
 
     it 'only camelizes the hash' do
       ob.build_theme
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 end

--- a/spec/options_builder/title_spec.rb
+++ b/spec/options_builder/title_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe '#build_title' do
 
     it 'adds shape key with the string as the value' do
       ob.build_title
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -46,7 +46,7 @@ RSpec.describe '#build_title' do
 
     it 'only camelizes the hash' do
       ob.build_title
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 end

--- a/spec/options_builder/tooltip_spec.rb
+++ b/spec/options_builder/tooltip_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe '#build_tooltip' do
 
     it 'adds show key with the boolean as the value' do
       ob.build_tooltip
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -46,7 +46,7 @@ RSpec.describe '#build_tooltip' do
 
     it 'only camelizes the hash' do
       ob.build_tooltip
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 end

--- a/spec/options_builder/xaxis_spec.rb
+++ b/spec/options_builder/xaxis_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe '#build_xaxis' do
 
     it 'choose xaxis string value over xtitle for the title' do
       ob.build_xaxis
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -77,7 +77,17 @@ RSpec.describe '#build_xaxis' do
 
     it 'will disregard x_sample' do
       ob.build_xaxis
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
+    end
+  end
+
+  context 'xaxis is empty' do
+    let(:options) { {} }
+    let(:expected_built) { { xaxis: nil } }
+
+    it 'returns nil value' do
+      ob.build_xaxis
+      expect(ob.built).to match(expected_built)
     end
   end
 end

--- a/spec/options_builder/yaxis_spec.rb
+++ b/spec/options_builder/yaxis_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe '#build_yaxis' do
 
     it 'choose yaxis string value over ytitle for the title' do
       ob.build_yaxis
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
     end
   end
 
@@ -54,7 +54,17 @@ RSpec.describe '#build_yaxis' do
 
     it 'choose type in yaxis over ytype' do
       ob.build_yaxis
-      expect(ob.built).to match(hash_including(expected_built))
+      expect(ob.built).to match(expected_built)
+    end
+  end
+
+  context 'yaxis is empty' do
+    let(:options) { {} }
+    let(:expected_built) { {yaxis: nil} }
+
+    it 'returns nil value' do
+      ob.build_yaxis
+      expect(ob.built).to match(expected_built)
     end
   end
 end

--- a/spec/utils/date_time_spec.rb
+++ b/spec/utils/date_time_spec.rb
@@ -189,8 +189,8 @@ RSpec.describe ApexCharts::Utils::DateTime do
     context 'input is anything else' do
       let(:input) { ['2'] }
 
-      it 'converts correctly' do
-        expect(type).to eq 'numeric'
+      it 'returns nil' do
+        expect(type).to eq nil
       end
     end
   end


### PR DESCRIPTION
- remove unnecessary hash_including
- utils datetime type returns nil when input is unknown
- remove xaxis and yaxis entirely when their contents are empty