### PR TITLE
Get empty series working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@ All notable changes to this project will be documented in this file.
 - Charts and series are autoloaded instead of required to prevent loading
   unused charts and series to memory
 
+### Fixed
+- Empty data series no longer throws an exception
+
 
 ## [0.1.6] - 2019-08-24
 ### Added
@@ -70,8 +73,8 @@ All notable changes to this project will be documented in this file.
 - Chart examples
 
 ### Changed
-- `mixed_chart`, `combo_chart`, `syncing_chart`, and 
-  `synchronized_chart` into `mixed_charts`, `combo_charts`, 
+- `mixed_chart`, `combo_chart`, `syncing_chart`, and
+  `synchronized_chart` into `mixed_charts`, `combo_charts`,
   `syncing_charts`, and `synchronized_charts` respectively
   as they should be
 

--- a/lib/apexcharts/charts/base.rb
+++ b/lib/apexcharts/charts/base.rb
@@ -25,9 +25,15 @@ module ApexCharts
     end
 
     def x_sample
-      return if series[:series].empty? || series[:series][0][:data].empty?
+      return if series_empty?
 
       series[:series][0][:data][0][:x]
+    end
+
+  private
+
+    def series_empty?
+      series[:series].empty? || series[:series][0][:data].empty?
     end
   end
 end

--- a/lib/apexcharts/charts/base.rb
+++ b/lib/apexcharts/charts/base.rb
@@ -25,7 +25,9 @@ module ApexCharts
     end
 
     def x_sample
-      series[:series][0][:data][0][:x]
+      unless series[:series].empty?
+        series[:series][0][:data][0][:x]
+      end
     end
   end
 end

--- a/lib/apexcharts/charts/base.rb
+++ b/lib/apexcharts/charts/base.rb
@@ -25,9 +25,9 @@ module ApexCharts
     end
 
     def x_sample
-      unless series[:series].empty?
-        series[:series][0][:data][0][:x]
-      end
+      return if series[:series].empty? || series[:series][0][:data].empty?
+
+      series[:series][0][:data][0][:x]
     end
   end
 end

--- a/lib/apexcharts/charts/bubble.rb
+++ b/lib/apexcharts/charts/bubble.rb
@@ -13,9 +13,9 @@ module ApexCharts
     end
 
     def x_sample
-      unless series[:series].empty?
-        series[:series][0][:data][0][0]
-      end
+      return if series[:series].empty? || series[:series][0][:data].empty?
+
+      series[:series][0][:data][0][0]
     end
   end
 end

--- a/lib/apexcharts/charts/bubble.rb
+++ b/lib/apexcharts/charts/bubble.rb
@@ -13,7 +13,9 @@ module ApexCharts
     end
 
     def x_sample
-      series[:series][0][:data][0][0]
+      unless series[:series].empty?
+        series[:series][0][:data][0][0]
+      end
     end
   end
 end

--- a/lib/apexcharts/charts/bubble.rb
+++ b/lib/apexcharts/charts/bubble.rb
@@ -13,7 +13,7 @@ module ApexCharts
     end
 
     def x_sample
-      return if series[:series].empty? || series[:series][0][:data].empty?
+      return if series_empty?
 
       series[:series][0][:data][0][0]
     end

--- a/lib/apexcharts/series/cartesian.rb
+++ b/lib/apexcharts/series/cartesian.rb
@@ -11,9 +11,7 @@ module ApexCharts
     end
 
     def build_series(data)
-      if data.empty?
-        return data
-      end
+      return data if data.empty?
 
       case data
       when Array

--- a/lib/apexcharts/series/cartesian.rb
+++ b/lib/apexcharts/series/cartesian.rb
@@ -11,6 +11,10 @@ module ApexCharts
     end
 
     def build_series(data)
+      if data.empty?
+        return data
+      end
+
       case data
       when Array
         build_series_from_array(data)

--- a/spec/charts/area_spec.rb
+++ b/spec/charts/area_spec.rb
@@ -34,4 +34,30 @@ RSpec.describe ApexCharts::AreaChart do
       expect(chart.mixed_series).to eq([])
     end
   end
+
+  context 'when a hash series is empty' do
+    let(:data) {
+      [
+        {
+          name: 'series',
+          data: []
+        }
+      ]
+    }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(outer_self, data, options)
+      expect(chart.chart_type).to eq('area')
+      expect(chart.more_options).to eq({})
+      expect(chart.mixed_series).to eq(
+        [
+          {
+            data: [],
+            name: 'series',
+            type: 'area'
+          }
+        ]
+      )
+    end
+  end
 end

--- a/spec/charts/area_spec.rb
+++ b/spec/charts/area_spec.rb
@@ -23,4 +23,15 @@ RSpec.describe ApexCharts::AreaChart do
       ]
     )
   end
+
+  context 'when the series is empty' do
+    let(:data) { [] }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(outer_self, data, options)
+      expect(chart.chart_type).to eq('area')
+      expect(chart.more_options).to eq({})
+      expect(chart.mixed_series).to eq([])
+    end
+  end
 end

--- a/spec/charts/bar_spec.rb
+++ b/spec/charts/bar_spec.rb
@@ -56,4 +56,20 @@ RSpec.describe ApexCharts::BarChart do
       )
     end
   end
+
+  context 'when the series is empty' do
+    let(:data) { [] }
+
+    it 'assigned properties correctly' do
+      expect(chart.chart_type).to eq('bar')
+      expect(chart.more_options).to eq(
+        plot_options: {
+          bar: {
+            horizontal: true
+          }
+        }
+      )
+      expect(chart.mixed_series).to eq([])
+    end
+  end
 end

--- a/spec/charts/bar_spec.rb
+++ b/spec/charts/bar_spec.rb
@@ -72,4 +72,35 @@ RSpec.describe ApexCharts::BarChart do
       expect(chart.mixed_series).to eq([])
     end
   end
+
+  context 'when a hash series is empty' do
+    let(:data) {
+      [
+        {
+          name: 'series',
+          data: []
+        }
+      ]
+    }
+
+    it 'assigned properties correctly' do
+      expect(chart.chart_type).to eq('bar')
+      expect(chart.more_options).to eq(
+        plot_options: {
+          bar: {
+            horizontal: true
+          }
+        }
+      )
+      expect(chart.mixed_series).to eq(
+        [
+          {
+            data: [],
+            name: 'series',
+            type: 'bar'
+          }
+        ]
+      )
+    end
+  end
 end

--- a/spec/charts/bubble_spec.rb
+++ b/spec/charts/bubble_spec.rb
@@ -10,4 +10,13 @@ RSpec.describe ApexCharts::BubbleChart do
     chart = described_class.new(data, options)
     expect(chart.chart_type).to eq('bubble')
   end
+
+  context 'when the series is empty' do
+    let(:data) { [] }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(data, options)
+      expect(chart.chart_type).to eq('bubble')
+    end
+  end
 end

--- a/spec/charts/bubble_spec.rb
+++ b/spec/charts/bubble_spec.rb
@@ -19,4 +19,20 @@ RSpec.describe ApexCharts::BubbleChart do
       expect(chart.chart_type).to eq('bubble')
     end
   end
+
+  context 'when a hash series is empty' do
+    let(:data) {
+      [
+        {
+          name: 'series',
+          data: []
+        }
+      ]
+    }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(data, options)
+      expect(chart.chart_type).to eq('bubble')
+    end
+  end
 end

--- a/spec/charts/candlestick_spec.rb
+++ b/spec/charts/candlestick_spec.rb
@@ -34,4 +34,30 @@ RSpec.describe ApexCharts::CandlestickChart do
       expect(chart.mixed_series).to eq([])
     end
   end
+
+  context 'when a hash series is empty' do
+    let(:data) {
+      [
+        {
+          name: 'series',
+          data: []
+        }
+      ]
+    }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(outer_self, data, options)
+      expect(chart.chart_type).to eq('candlestick')
+      expect(chart.more_options).to eq({})
+      expect(chart.mixed_series).to eq(
+        [
+          {
+            data: [],
+            name: 'series',
+            type: 'candlestick'
+          }
+        ]
+      )
+    end
+  end
 end

--- a/spec/charts/candlestick_spec.rb
+++ b/spec/charts/candlestick_spec.rb
@@ -23,4 +23,15 @@ RSpec.describe ApexCharts::CandlestickChart do
       ]
     )
   end
+
+  context 'when the series is empty' do
+    let(:data) { [] }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(outer_self, data, options)
+      expect(chart.chart_type).to eq('candlestick')
+      expect(chart.more_options).to eq({})
+      expect(chart.mixed_series).to eq([])
+    end
+  end
 end

--- a/spec/charts/cartesian_spec.rb
+++ b/spec/charts/cartesian_spec.rb
@@ -22,4 +22,21 @@ RSpec.describe ApexCharts::CartesianChart do
       expect(chart.more_options).to eq({})
     end
   end
+
+  context 'when a hash series is empty' do
+    let(:data) {
+      [
+        {
+          name: 'series',
+          data: []
+        }
+      ]
+    }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(outer_self, data, options)
+      expect(chart.chart_type).to eq(nil)
+      expect(chart.more_options).to eq({})
+    end
+  end
 end

--- a/spec/charts/cartesian_spec.rb
+++ b/spec/charts/cartesian_spec.rb
@@ -12,4 +12,14 @@ RSpec.describe ApexCharts::CartesianChart do
     expect(chart.chart_type).to eq(nil)
     expect(chart.more_options).to eq({})
   end
+
+  context 'when the series is empty' do
+    let(:data) { [] }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(outer_self, data, options)
+      expect(chart.chart_type).to eq(nil)
+      expect(chart.more_options).to eq({})
+    end
+  end
 end

--- a/spec/charts/column_spec.rb
+++ b/spec/charts/column_spec.rb
@@ -29,4 +29,21 @@ RSpec.describe ApexCharts::ColumnChart do
       ]
     )
   end
+
+  context 'when series is empty' do
+    let(:data) { [] }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(outer_self, data, options)
+      expect(chart.chart_type).to eq('bar')
+      expect(chart.more_options).to eq(
+        plot_options: {
+          bar: {
+            horizontal: false
+          }
+        }
+      )
+      expect(chart.mixed_series).to eq([])
+    end
+  end
 end

--- a/spec/charts/column_spec.rb
+++ b/spec/charts/column_spec.rb
@@ -46,4 +46,36 @@ RSpec.describe ApexCharts::ColumnChart do
       expect(chart.mixed_series).to eq([])
     end
   end
+
+  context 'when a hash series is empty' do
+    let(:data) {
+      [
+        {
+          name: 'series',
+          data: []
+        }
+      ]
+    }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(outer_self, data, options)
+      expect(chart.chart_type).to eq('bar')
+      expect(chart.more_options).to eq(
+        plot_options: {
+          bar: {
+            horizontal: false
+          }
+        }
+      )
+      expect(chart.mixed_series).to eq(
+        [
+          {
+            name: 'series',
+            data: [],
+            type: 'bar'
+          }
+        ]
+      )
+    end
+  end
 end

--- a/spec/charts/donut_spec.rb
+++ b/spec/charts/donut_spec.rb
@@ -15,4 +15,13 @@ RSpec.describe ApexCharts::DonutChart do
     chart = described_class.new(data, options)
     expect(chart.chart_type).to eq('donut')
   end
+
+  context 'when the series is empty' do
+    let(:data) { [] }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(data, options)
+      expect(chart.chart_type).to eq('donut')
+    end
+  end
 end

--- a/spec/charts/donut_spec.rb
+++ b/spec/charts/donut_spec.rb
@@ -24,4 +24,20 @@ RSpec.describe ApexCharts::DonutChart do
       expect(chart.chart_type).to eq('donut')
     end
   end
+
+  context 'when a hash series is empty' do
+    let(:data) {
+      [
+        {
+          name: 'series',
+          data: []
+        }
+      ]
+    }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(data, options)
+      expect(chart.chart_type).to eq('donut')
+    end
+  end
 end

--- a/spec/charts/heatmap_spec.rb
+++ b/spec/charts/heatmap_spec.rb
@@ -19,4 +19,20 @@ RSpec.describe ApexCharts::HeatmapChart do
       expect(chart.chart_type).to eq('heatmap')
     end
   end
+
+  context 'when a hash series is empty' do
+    let(:data) {
+      [
+        {
+          name: 'series',
+          data: []
+        }
+      ]
+    }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(data, options)
+      expect(chart.chart_type).to eq('heatmap')
+    end
+  end
 end

--- a/spec/charts/heatmap_spec.rb
+++ b/spec/charts/heatmap_spec.rb
@@ -10,4 +10,13 @@ RSpec.describe ApexCharts::HeatmapChart do
     chart = described_class.new(data, options)
     expect(chart.chart_type).to eq('heatmap')
   end
+
+  context 'when the series is empty' do
+    let(:data) { [] }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(data, options)
+      expect(chart.chart_type).to eq('heatmap')
+    end
+  end
 end

--- a/spec/charts/line_spec.rb
+++ b/spec/charts/line_spec.rb
@@ -23,4 +23,15 @@ RSpec.describe ApexCharts::LineChart do
       ]
     )
   end
+
+  context 'when the series is empty' do
+    let(:data) { [] }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(outer_self, data, options)
+      expect(chart.chart_type).to eq('line')
+      expect(chart.more_options).to eq({})
+      expect(chart.mixed_series).to eq([])
+    end
+  end
 end

--- a/spec/charts/line_spec.rb
+++ b/spec/charts/line_spec.rb
@@ -34,4 +34,30 @@ RSpec.describe ApexCharts::LineChart do
       expect(chart.mixed_series).to eq([])
     end
   end
+
+  context 'when a hash series is empty' do
+    let(:data) {
+      [
+        {
+          name: 'series',
+          data: []
+        }
+      ]
+    }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(outer_self, data, options)
+      expect(chart.chart_type).to eq('line')
+      expect(chart.more_options).to eq({})
+      expect(chart.mixed_series).to eq(
+        [
+          {
+            data: [],
+            name: 'series',
+            type: 'line'
+          }
+        ]
+      )
+    end
+  end
 end

--- a/spec/charts/pie_spec.rb
+++ b/spec/charts/pie_spec.rb
@@ -17,7 +17,23 @@ RSpec.describe ApexCharts::PieChart do
   end
 
   context 'when the series is empty' do
-    let(:data){ [] }
+    let(:data) { [] }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(data, options)
+      expect(chart.chart_type).to eq('pie')
+    end
+  end
+
+  context 'when a hash series is empty' do
+    let(:data) {
+      [
+        {
+          name: 'series',
+          data: []
+        }
+      ]
+    }
 
     it 'assigned properties correctly' do
       chart = described_class.new(data, options)

--- a/spec/charts/pie_spec.rb
+++ b/spec/charts/pie_spec.rb
@@ -15,4 +15,13 @@ RSpec.describe ApexCharts::PieChart do
     chart = described_class.new(data, options)
     expect(chart.chart_type).to eq('pie')
   end
+
+  context 'when the series is empty' do
+    let(:data){ [] }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(data, options)
+      expect(chart.chart_type).to eq('pie')
+    end
+  end
 end

--- a/spec/charts/polar_spec.rb
+++ b/spec/charts/polar_spec.rb
@@ -24,4 +24,20 @@ RSpec.describe ApexCharts::PolarChart do
       expect(chart.chart_type).to eq(nil)
     end
   end
+
+  context 'when a hash series is empty' do
+    let(:data) {
+      [
+        {
+          name: 'series',
+          data: []
+        }
+      ]
+    }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(data, options)
+      expect(chart.chart_type).to eq(nil)
+    end
+  end
 end

--- a/spec/charts/polar_spec.rb
+++ b/spec/charts/polar_spec.rb
@@ -15,4 +15,13 @@ RSpec.describe ApexCharts::PolarChart do
     chart = described_class.new(data, options)
     expect(chart.chart_type).to eq(nil)
   end
+
+  context 'when the series is empty' do
+    let(:data) { [] }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(data, options)
+      expect(chart.chart_type).to eq(nil)
+    end
+  end
 end

--- a/spec/charts/radar_spec.rb
+++ b/spec/charts/radar_spec.rb
@@ -10,4 +10,13 @@ RSpec.describe ApexCharts::RadarChart do
     chart = described_class.new(data, options)
     expect(chart.chart_type).to eq('radar')
   end
+
+  context 'when the series is empty' do
+    let(:data) { [] }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(data, options)
+      expect(chart.chart_type).to eq('radar')
+    end
+  end
 end

--- a/spec/charts/radar_spec.rb
+++ b/spec/charts/radar_spec.rb
@@ -19,4 +19,20 @@ RSpec.describe ApexCharts::RadarChart do
       expect(chart.chart_type).to eq('radar')
     end
   end
+
+  context 'when a hash series is empty' do
+    let(:data) {
+      [
+        {
+          name: 'series',
+          data: []
+        }
+      ]
+    }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(data, options)
+      expect(chart.chart_type).to eq('radar')
+    end
+  end
 end

--- a/spec/charts/radial_bar_spec.rb
+++ b/spec/charts/radial_bar_spec.rb
@@ -15,4 +15,13 @@ RSpec.describe ApexCharts::RadialBarChart do
     chart = described_class.new(data, options)
     expect(chart.chart_type).to eq('radialBar')
   end
+
+  context 'when the series is empty' do
+    let(:data) { [] }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(data, options)
+      expect(chart.chart_type).to eq('radialBar')
+    end
+  end
 end

--- a/spec/charts/radial_bar_spec.rb
+++ b/spec/charts/radial_bar_spec.rb
@@ -24,4 +24,20 @@ RSpec.describe ApexCharts::RadialBarChart do
       expect(chart.chart_type).to eq('radialBar')
     end
   end
+
+  context 'when a hash series is empty' do
+    let(:data) {
+      [
+        {
+          name: 'series',
+          data: []
+        }
+      ]
+    }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(data, options)
+      expect(chart.chart_type).to eq('radialBar')
+    end
+  end
 end

--- a/spec/charts/range_bar_spec.rb
+++ b/spec/charts/range_bar_spec.rb
@@ -56,4 +56,20 @@ RSpec.describe ApexCharts::RangeBarChart do
       )
     end
   end
+
+  context 'when the series is empty' do
+    let(:data) { [] }
+
+    it 'assigned properties correctly' do
+      expect(chart.chart_type).to eq('rangeBar')
+      expect(chart.more_options).to eq(
+        plot_options: {
+          bar: {
+            horizontal: true
+          }
+        }
+      )
+      expect(chart.mixed_series).to eq([])
+    end
+  end
 end

--- a/spec/charts/range_bar_spec.rb
+++ b/spec/charts/range_bar_spec.rb
@@ -72,4 +72,35 @@ RSpec.describe ApexCharts::RangeBarChart do
       expect(chart.mixed_series).to eq([])
     end
   end
+
+  context 'when a hash series is empty' do
+    let(:data) {
+      [
+        {
+          name: 'series',
+          data: []
+        }
+      ]
+    }
+
+    it 'assigned properties correctly' do
+      expect(chart.chart_type).to eq('rangeBar')
+      expect(chart.more_options).to eq(
+        plot_options: {
+          bar: {
+            horizontal: true
+          }
+        }
+      )
+      expect(chart.mixed_series).to eq(
+        [
+          {
+            data: [],
+            name: 'series',
+            type: 'rangeBar'
+          }
+        ]
+      )
+    end
+  end
 end

--- a/spec/charts/scatter_spec.rb
+++ b/spec/charts/scatter_spec.rb
@@ -23,4 +23,15 @@ RSpec.describe ApexCharts::ScatterChart do
       ]
     )
   end
+
+  context 'when the series is empty' do
+    let(:data) { [] }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(outer_self, data, options)
+      expect(chart.chart_type).to eq('scatter')
+      expect(chart.more_options).to eq({})
+      expect(chart.mixed_series).to eq([])
+    end
+  end
 end

--- a/spec/charts/scatter_spec.rb
+++ b/spec/charts/scatter_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ApexCharts::ScatterChart do
     end
   end
 
-  context 'when the series is empty' do
+  context 'when a hash series is empty' do
     let(:data) {
       [
         {

--- a/spec/charts/scatter_spec.rb
+++ b/spec/charts/scatter_spec.rb
@@ -34,4 +34,30 @@ RSpec.describe ApexCharts::ScatterChart do
       expect(chart.mixed_series).to eq([])
     end
   end
+
+  context 'when the series is empty' do
+    let(:data) {
+      [
+        {
+          name: 'series',
+          data: []
+        }
+      ]
+    }
+
+    it 'assigned properties correctly' do
+      chart = described_class.new(outer_self, data, options)
+      expect(chart.chart_type).to eq('scatter')
+      expect(chart.more_options).to eq({})
+      expect(chart.mixed_series).to eq(
+        [
+          {
+            data: [],
+            name: 'series',
+            type: 'scatter'
+          }
+        ]
+      )
+    end
+  end
 end


### PR DESCRIPTION
Don't sample x-axis values unless there are values there to sample. Also
don't try and sanitise empty datasets, just return the empty dataset.
The underlying library supports empty sets.

This works for both plain empty series, and series with a label but no data.

E.g.

```
<%= column_chart([], {
title: 'My graph',
xtitle: 'Horizontal Series',
ytitle: 'Vertical Series',
theme: 'mytheme'
}) %>
```

and

```
<%= column_chart(
  [
    {
      name: 'Series A',
      data: []
    },
  ],
title: 'My graph',
xtitle: 'Horizontal Series',
ytitle: 'Vertical Series',
theme: 'mytheme'
}) %>
```

Would now both be valid.

This is a fix for bug 41