### PR TITLE
Add support for reversed y-axis

### DIFF
--- a/lib/apexcharts/options/y_axis.rb
+++ b/lib/apexcharts/options/y_axis.rb
@@ -7,6 +7,7 @@ module ApexCharts
       forceNiceScale
       logarithmic
       opposite
+      reversed
       seriesName
       show
       showAlways


### PR DESCRIPTION
Fixes https://github.com/styd/apexcharts.rb/issues/44

Setup code
```ruby
    start_date = Date.parse("01-01-2019")
    end_date = Date.parse("20-01-2019")
    date_range = start_date..end_date

    @inactive = date_range.map do |date|
        [date, rand(10)]
      end.to_h

    @active = date_range.map do |date|
        [date, rand(100)]
      end.to_h

    @series = [
      {name: "Inactive", data: @inactive},
      {name: "Active", data: @active}
    ]
```

With options
```ruby
    @options = {
      title: 'Properties Growth',
      subtitle: 'Grouped Per Week',
      xtitle: 'Week',
      ytitle: 'Properties',
      stacked: true
  }
```

<img width="838" alt="Screenshot 2019-10-16 at 15 00 01" src="https://user-images.githubusercontent.com/62895/66926533-244d9b00-f026-11e9-9eaa-aecec1cb8e04.png">

With options
 ```ruby
    @options = {
      title: 'Properties Growth',
      subtitle: 'Grouped Per Week',
      xtitle: 'Week',
      ytitle: 'Properties',
      stacked: true,
      yaxis: { reversed: true }
    }
```

<img width="839" alt="Screenshot 2019-10-16 at 14 59 33" src="https://user-images.githubusercontent.com/62895/66926570-316a8a00-f026-11e9-9c5a-79681ed99101.png">
(note the values are randomly generated, so they don't match in the two screenshots)