### PR TITLE
Fix mixed_charts no longer working

### DIFF
--- a/lib/apexcharts/charts.rb
+++ b/lib/apexcharts/charts.rb
@@ -1,13 +1,20 @@
 # frozen_string_literal: true
 
+
+require_relative 'charts/features/annotations'
+require_relative 'charts/features/mixable'
+
 module ApexCharts
   %w(
-    base cartesian line area bar column scatter candlestick
-    heatmap bubble radar mixed syncing polar pie donut
+    base cartesian line area bar column scatter
+    candlestick heatmap bubble radar polar pie donut
   ).each do |type|
     autoload :"#{type.capitalize}Chart", "apexcharts/charts/#{type}.rb"
   end
 
   autoload :RangeBarChart, 'apexcharts/charts/range_bar.rb'
   autoload :RadialBarChart, 'apexcharts/charts/radial_bar.rb'
+
+  autoload :MixedCharts, 'apexcharts/charts/mixed.rb'
+  autoload :SyncingCharts, 'apexcharts/charts/syncing.rb'
 end

--- a/lib/apexcharts/charts/cartesian.rb
+++ b/lib/apexcharts/charts/cartesian.rb
@@ -1,7 +1,5 @@
 # frozen_string_literal: true
 
-require_relative 'features/annotations'
-require_relative 'features/mixable'
 require_relative '../utils/hash'
 
 module ApexCharts
@@ -37,7 +35,7 @@ module ApexCharts
     end
 
     def method_missing(method, *args, &block)
-      if @outer_self.respond_to?(method)
+      if @outer_self.respond_to?(method, true)
         @outer_self.send method, *args, &block
       else
         super
@@ -45,7 +43,7 @@ module ApexCharts
     end
 
     def respond_to_missing?(method, *args)
-      @outer_self.respond_to?(method) || super
+      @outer_self.respond_to?(method, true) || super
     end
 
   protected
@@ -57,7 +55,7 @@ module ApexCharts
     end
 
     def brush?
-      @options[:chart][:brush]&.[](:enabled) && \
+      @options[:chart][:brush]&.[](:enabled) &&
         !@options[:chart][:selection]&.[](:xaxis)
     end
 

--- a/lib/apexcharts/charts/mixed.rb
+++ b/lib/apexcharts/charts/mixed.rb
@@ -19,6 +19,10 @@ module ApexCharts
       build_selection_range if brush?
     end
 
+    def chart_type
+      'area' # chosen default
+    end
+
     def line_chart(data, options={}, &block)
       outer_self = eval('self', block.binding, __FILE__, __LINE__) if block_given?
       @series[:series] +=
@@ -50,7 +54,7 @@ module ApexCharts
     end
 
     def method_missing(method, *args, &block)
-      if @outer_self.respond_to?(method)
+      if @outer_self.respond_to?(method, true)
         @outer_self.send method, *args, &block
       else
         super
@@ -70,7 +74,7 @@ module ApexCharts
     end
 
     def brush?
-      @options[:chart][:brush]&.[](:enabled) && \
+      @options[:chart][:brush]&.[](:enabled) &&
         !@options[:chart][:selection]&.[](:xaxis)
     end
 

--- a/lib/apexcharts/charts/syncing.rb
+++ b/lib/apexcharts/charts/syncing.rb
@@ -62,7 +62,7 @@ module ApexCharts
     end
 
     def method_missing(method, *args, &block)
-      if @outer_self.respond_to? method, *args
+      if @outer_self.respond_to?(method, true)
         @outer_self.send method, *args, &block
       else
         super


### PR DESCRIPTION
This should fix #49.
While fixing the bug, I found many other bugs:
- Syncing is also not working any more after
  autoloading charts
- Mixed charts renders chart with type: null,
  causing it to only display legends
- apexcharts_id and apexcharts_group cannot be
  accessed from mixed_charts and syncing_charts
  respectively

All of this is caused by me not adding specs for
those charts. I will add them soon.