### PR TITLE
Deprecate local palette

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ All notable changes to this project will be documented in this file.
   legend, markers, plotOptions, theme, xAxis, and yAxis
 
 ### Changed
+- Local palette with public API `create_palette` and `destroy_palette`
+  is deprecated
 - Make obsolete previously deprecated require directory for `prefix_with_apex`
 - ApexCharts.JS version from 3.18.0 to 3.19.2
 

--- a/README.md
+++ b/README.md
@@ -682,26 +682,6 @@ If later for some reason I don't know you want to destroy the palette you can us
 ApexCharts::Theme.destroy "rainbow"
 ```
 
-### Local Palette
-
-To create local palettes to be used only for current thread (usually for the duration
-of a request), you can use the `create_palette` helper. The theme will only be available
-on that page and inside its partials after the palette created.
-
-For example:
-
-```ruby
-create_palette "ephemeral", ["#ab356d", "#12cdf3", "#665572", "#ababac"]
-```
-
-To destroy the palette:
-
-```ruby
-destroy_palette "ephemeral"
-```
-
-on the same page or in its partials. Otherwise, nothing will happen.
-
 
 ## Use Alongside Other Charting Libraries
 

--- a/lib/apex_charts/helper.rb
+++ b/lib/apex_charts/helper.rb
@@ -149,6 +149,9 @@ module ApexCharts
     end
 
     def create_palette(palette_name, colors)
+      warn "`create_palette' and `destroy_palette` are deprecated " +
+           "and will be removed in the next release."
+
       Theme::Local.create palette_name, colors
     end
 


### PR DESCRIPTION
Local or ephemeral palette doesn't seem useful. People can just create multiple global palettes and use them on conditions. 

Besides, using fiber-local or even thread-local can have unexpected results on a site with busy traffic and server with connection thread pool. For example, if someone to check first whether `Theme::Local.palettes[:a_palette_name]` exists or not before invoking `create_palette` and decided not to create the palette if exists (for some crazy reason), he/she will use the palette defined in the previous request that creates a local palette too. But this case is very unlikely. So the main reason for deprecation is the lack of usefulness.