### PR TITLE
Add Ruby 3.1 to CI

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,7 +15,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: [2.5, 2.6, 2.7, 3.0]
+        ruby: [2.5, 2.6, 2.7, '3.0', 3.1]
     runs-on: ${{ matrix.os }}
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
This PR adds Ruby 3.1 to the CI matrix.

The value 3.0 is also enclosed in quotes with this PR to account for the fact that YAML rounds an unquoted 3.0 to 3, which will load the latest Ruby 3.x as opposed to the latest Ruby 3.0.x.  Quoting ensures that the final zero digit is respected.