### PR TITLE
Adds Ruby 3.2 to the CI matrix.  Also updates the checkout action version

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -15,16 +15,15 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        ruby: [2.5, 2.6, 2.7, '3.0', 3.1]
+        ruby: [2.5, 2.6, 2.7, '3.0', 3.1, 3.2]
     runs-on: ${{ matrix.os }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
+        bundler-cache: true
     - name: Build and test with Rake
       run: |
-        gem install bundler
-        bundle install --jobs 4 --retry 3
         bundle exec rake

--- a/spec/charts/syncing_charts_spec.rb
+++ b/spec/charts/syncing_charts_spec.rb
@@ -22,11 +22,11 @@ RSpec.describe ApexCharts::Charts::SyncingCharts do
     end
 
     expect(ApexCharts::Charts::LineChart).to(
-      receive(:new).with(nil, line_data, **sync_options, **line_options, id: 'chart-1')
+      receive(:new).with(nil, line_data, { id: 'chart-1' }.merge(sync_options).merge(line_options))
                    .and_call_original
     )
     expect(ApexCharts::Charts::AreaChart).to(
-      receive(:new).with(nil, area_data, **sync_options, **area_options, id: 'chart-2')
+      receive(:new).with(nil, area_data, { id: 'chart-2' }.merge(sync_options).merge(area_options))
                    .and_call_original
     )
 


### PR DESCRIPTION
Includes a minor code change in a spec to clarify that the argument is supposed to be a hash, not a positional argument.  Necessary to run green on 3.2

Runs green on my fork.