### PR TITLE
Update function substitution regex to work better under Rails

### DIFF
--- a/lib/apex_charts/renderer.rb
+++ b/lib/apex_charts/renderer.rb
@@ -54,9 +54,11 @@ module ApexCharts
     end
 
     def substitute_function_object(json)
-      json.gsub(/{"function":{"args":"(?<args>.*?)","body":"(?<body>.*?)"}}/) do
-        body = "\"#{$LAST_MATCH_INFO&.[](:body)}\"".undump
-        "function(#{$LAST_MATCH_INFO&.[](:args)}){#{body}}"
+      json.gsub(/{"function":{"args":"(?<args>[^"]*)","body":"(?<body>(?:[^"\\]|\\.)*?)"}}/m) do
+        match = $~
+        args = match[:args]
+        body = "\"#{match[:body]}\"".undump
+        "function(#{args}){#{body}}"
       end
     end
 


### PR DESCRIPTION
For some JS formatter functions, the regex in `renderer#substitute_function_object` was not parsing correctly when run under Rails and was returning empty function declarations in the rendered output. I worked with AI for longer than I care to admit to try and create a failing test case to match what I was seeing in Rails. The same JSON getting passed to `#substitute_function_object` was working in the standalone gem test cases, but not when the gem was running within the Rails application. I'm guessing it has something to do with how JSON conversion is patched within Rails and how strings are being escaped.

For example, the following JS formatter function:
```
    labels: {
      formatter: {
        function:
        {
          args: "val",
          body: "return new Date(val).getUTCFullYear().toString();"
        }
      }
    }
```
results in the following rendered content before this change:
```
"labels":{"formatter":function(){}}},
```
after this change, it renders the expected content:
```
"labels":{"formatter":function(val){return new Date(val).getUTCFullYear().toString();}}},
```