### PR TITLE
Add turbo load integration (re-render chart)

### DIFF
--- a/lib/apex_charts/renderer.rb
+++ b/lib/apex_charts/renderer.rb
@@ -38,23 +38,31 @@ module ApexCharts
           (function() {
             var createChart = function() {
               document.removeEventListener("turbo:load", createChart, true);
+              document.removeEventListener("turbolinks:load", createChart, true);
               window.removeEventListener("load", createChart, true);
 
               #{indent(js)}
               var destroyChart = function() {
-                document.removeEventListener("turbo:before-cache", destroyChart, true);
+                document.removeEventListener("turbo:before-render", destroyChart, true);
+                document.removeEventListener("turbolinks:before-render", destroyChart, true);
                 if (#{variable}) {
                   #{variable}.destroy();
                   #{variable} = null;
                 }
               };
 
-              document.addEventListener("turbo:before-cache", destroyChart, true);
+              document.addEventListener("turbo:before-render", destroyChart, true);
+              document.addEventListener("turbolinks:before-render", destroyChart, true);
             };
 
-            if (!(document.documentElement.hasAttribute ? document.documentElement.hasAttribute("data-turbo-preview") : document.documentElement.getAttribute("data-turbo-preview"))) {
+            var isPreview = document.documentElement.hasAttribute ?
+              (document.documentElement.hasAttribute("data-turbo-preview") || document.documentElement.hasAttribute("data-turbolinks-preview")) :
+              (document.documentElement.getAttribute("data-turbo-preview") || document.documentElement.getAttribute("data-turbolinks-preview"));
+
+            if (!isPreview) {
               if (window.addEventListener) {
                 document.addEventListener("turbo:load", createChart, true);
+                document.addEventListener("turbolinks:load", createChart, true);
                 window.addEventListener("load", createChart, true);
               } else if (window.attachEvent) {
                 window.attachEvent("onload", createChart);
@@ -108,9 +116,9 @@ module ApexCharts
 
     def height
       chart_height = options.dig(:chart, :height)
-      if chart_height
-        "#{chart_height.to_i}px"
-      end
+      return unless chart_height
+
+      "#{chart_height.to_i}px"
     end
 
     def style

--- a/lib/apex_charts/renderer.rb
+++ b/lib/apex_charts/renderer.rb
@@ -37,14 +37,30 @@ module ApexCharts
         <<~DEFERRED
           (function() {
             var createChart = function() {
+              document.removeEventListener("turbo:load", createChart, true);
+              window.removeEventListener("load", createChart, true);
+
               #{indent(js)}
+              var destroyChart = function() {
+                document.removeEventListener("turbo:before-cache", destroyChart, true);
+                if (#{variable}) {
+                  #{variable}.destroy();
+                  #{variable} = null;
+                }
+              };
+
+              document.addEventListener("turbo:before-cache", destroyChart, true);
             };
-            if (window.addEventListener) {
-              window.addEventListener("load", createChart, true);
-            } else if (window.attachEvent) {
-              window.attachEvent("onload", createChart);
-            } else {
-              createChart();
+
+            if (!(document.documentElement.hasAttribute ? document.documentElement.hasAttribute("data-turbo-preview") : document.documentElement.getAttribute("data-turbo-preview"))) {
+              if (window.addEventListener) {
+                document.addEventListener("turbo:load", createChart, true);
+                window.addEventListener("load", createChart, true);
+              } else if (window.attachEvent) {
+                window.attachEvent("onload", createChart);
+              } else {
+                createChart();
+              }
             }
           })();
         DEFERRED

--- a/lib/apex_charts/renderer.rb
+++ b/lib/apex_charts/renderer.rb
@@ -116,9 +116,9 @@ module ApexCharts
 
     def height
       chart_height = options.dig(:chart, :height)
-      return unless chart_height
-
-      "#{chart_height.to_i}px"
+      if chart_height
+        "#{chart_height.to_i}px"
+      end
     end
 
     def style

--- a/spec/renderer_spec.rb
+++ b/spec/renderer_spec.rb
@@ -67,6 +67,13 @@ RSpec.describe ApexCharts::Renderer do
         expect(html).to include 'var createChart = function()'
         expect(html).to include 'window.addEventListener'
       end
+
+      it 'includes Turbo event integration' do
+        html = described_class.render(options.merge({defer: true}))
+
+        expect(html).to include 'turbo:load'
+        expect(html).to include 'turbo:before-cache'
+      end
     end
 
     context 'when module = true' do

--- a/spec/renderer_spec.rb
+++ b/spec/renderer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ApexCharts::Renderer do
     end
 
     context 'when global options are set' do
-      let(:default_options) { {tootip: true} }
+      let(:default_options) { { tootip: true } }
 
       before do
         allow(ApexCharts.config)

--- a/spec/renderer_spec.rb
+++ b/spec/renderer_spec.rb
@@ -39,7 +39,7 @@ RSpec.describe ApexCharts::Renderer do
     end
 
     context 'when global options are set' do
-      let(:default_options) { { tootip: true } }
+      let(:default_options) { {tootip: true} }
 
       before do
         allow(ApexCharts.config)
@@ -68,11 +68,13 @@ RSpec.describe ApexCharts::Renderer do
         expect(html).to include 'window.addEventListener'
       end
 
-      it 'includes Turbo event integration' do
+      it 'includes Turbo and Turbolinks event integration' do
         html = described_class.render(options.merge({defer: true}))
 
         expect(html).to include 'turbo:load'
-        expect(html).to include 'turbo:before-cache'
+        expect(html).to include 'turbo:before-render'
+        expect(html).to include 'turbolinks:load'
+        expect(html).to include 'turbolinks:before-render'
       end
     end
 


### PR DESCRIPTION
Based on the patch posted here: https://github.com/styd/apexcharts.rb/discussions/88#discussioncomment-13093382

Update `defer` in `renderer.rb` to add an event listener for `turbo:load`. 
- creates chart on either `turbo:load` or `load`
- on creating chart,  adds an event listener for `turbo:before-chache` to destroy the chart before frame reload
- charts are not rendered during turbo preview states

Added test to check for turbo integration. 

Note: Not tested with turbo_streams, but based on documentation does not support partial page updates via turbo_stream.

Should work whether turbo is used or not.